### PR TITLE
Add URL to addon config

### DIFF
--- a/doods-amd64/config.json
+++ b/doods-amd64/config.json
@@ -2,6 +2,7 @@
   "name": "DOODS-amd64",
   "version": "2",
   "slug": "doods-amd64",
+  "url": "https://github.com/snowzach/hassio-addons/tree/master/doods-amd64",
   "description": "Distributed Open Object Detection Service for AMD64 SSE4.2",
   "arch": [
     "armhf",

--- a/doods/config.json
+++ b/doods/config.json
@@ -2,6 +2,7 @@
   "name": "DOODS",
   "version": "2",
   "slug": "doods",
+  "url": "https://github.com/snowzach/hassio-addons/tree/master/doods",
   "description": "Distributed Open Object Detection Service",
   "arch": [
     "armhf",

--- a/rts2p/config.json
+++ b/rts2p/config.json
@@ -2,6 +2,7 @@
   "name": "RTS2P",
   "version": "1",
   "slug": "rts2p",
+  "url": "https://github.com/snowzach/hassio-addons/tree/master/rts2p",
   "description": "RTSP Proxy Server",
   "arch": [
     "armhf",


### PR DESCRIPTION
This adds a URL parameter to the addon's configuration file.

When the addon is displayed in Home Assistant, it includes a link back to the addon's source. Currently this URL goes to `null` since the URL parameter is not set within the `config.json` for the addons. See screenshot below for the current behavior.

This PR adds the URL parameter to each addon in this repository, which links to the specific github page for it.

![image](https://user-images.githubusercontent.com/43505983/93154885-c95b7280-f6d2-11ea-8769-bd70c49d2b63.png)
