### PR TITLE
Add Support for the noavx variant to Home Assistant

### DIFF
--- a/doods-novax/Dockerfile
+++ b/doods-novax/Dockerfile
@@ -1,0 +1,2 @@
+FROM snowzach/doods:noavx
+CMD ["/opt/doods/doods", "-c", "/data/options.json", "api"]

--- a/doods-novax/README.md
+++ b/doods-novax/README.md
@@ -2,7 +2,7 @@
 
 See https://github.com/snowzach/doods for more documentation.
 
-This image supports AMD64 CPU's with SSE4.2 instructions
+This image supports AMD64 CPU's without SSE4.2 instructions
 
 
 ### Models

--- a/doods-novax/README.md
+++ b/doods-novax/README.md
@@ -1,0 +1,43 @@
+## DOODS - Distributed Open Object Detection Service
+
+See https://github.com/snowzach/doods for more documentation.
+
+This image supports AMD64 CPU's with SSE4.2 instructions
+
+
+### Models
+
+This add-on maps the /share directory by default. The default configuration uses the built in model.
+
+Place your custom models in something like /share/doods and you can access them from within the container when you configure it.
+
+For example:
+
+```
+{
+  "server": {
+    "port": "8080"
+  },
+  "auth_key": "",
+  "doods.detectors": [
+    {
+      "name": "default",
+      "type": "tflite",
+      "modelFile": "/opt/doods/models/coco_ssd_mobilenet_v1_1.0_quant.tflite",
+      "labelFile": "/opt/doods/models/coco_labels0.txt",
+      "numThreads": 1,
+      "numConcurrent": 1,
+      "hwAccel": false
+    },
+    {
+      "name": "tensorflow",
+      "type": "tensorflow",
+      "modelFile": "/share/doods/faster_rcnn_inception_v2_coco_2018_01_28.pb",
+      "labelFile": "/share/doods/coco_labels1.txt",
+      "numThreads": 1,
+      "numConcurrent": 1,
+      "hwAccel": false
+    }
+  ]
+}
+```

--- a/doods-novax/build.json
+++ b/doods-novax/build.json
@@ -1,0 +1,8 @@
+{
+  "build_from": {
+    "armhf": "snowzach/doods:arm32",
+    "armv7": "snowzach/doods:arm32",
+    "aarch64": "snowzach/doods:arm64",
+    "amd64": "snowzach/doods:noavx"
+  }
+}

--- a/doods-novax/config.json
+++ b/doods-novax/config.json
@@ -1,0 +1,65 @@
+{
+  "name": "DOODS-noavx",
+  "version": "2",
+  "slug": "doods-noavx",
+  "url": "https://github.com/snowzach/hassio-addons/tree/master/doods-noavx",
+  "description": "Distributed Open Object Detection Service for AMD64 SSE4.2",
+  "arch": [
+    "armhf",
+    "armv7",
+    "aarch64",
+    "amd64"
+  ],
+  "startup": "services",
+  "map": ["share"],
+  "usb": true,
+  "options": {
+    "server": {
+      "port": "8080"
+    },
+    "auth_key": "",
+    "doods.detectors": [
+      {
+        "name": "default",
+        "type": "tflite",
+        "modelFile": "/opt/doods/models/coco_ssd_mobilenet_v1_1.0_quant.tflite",
+        "labelFile": "/opt/doods/models/coco_labels0.txt",
+        "numThreads": 1,
+        "numConcurrent": 1,
+        "hwAccel": false
+      },
+      {
+        "name": "tensorflow",
+        "type": "tensorflow",
+        "modelFile": "/opt/doods/models/faster_rcnn_inception_v2_coco_2018_01_28.pb",
+        "labelFile": "/opt/doods/models/coco_labels1.txt",
+        "numThreads": 1,
+        "numConcurrent": 1,
+        "hwAccel": false
+      }
+    ]
+  },
+  "schema": {
+    "server": {
+      "port": "port?"
+    },
+    "doods.detectors": [
+      {
+        "name": "str",
+        "type": "str",
+        "modelFile": "str",
+        "labelFile": "str?",
+        "numThreads": "int?",
+        "numConcurrent": "int?",
+        "hwAccel": "bool?"
+      }
+    ],
+    "auth_key": "str?"
+  },
+  "ports": {
+    "8080/tcp": 8080
+  },
+  "ports_description": {
+    "8080/tcp": "DOODS port"
+  }
+}

--- a/doods-novax/config.json
+++ b/doods-novax/config.json
@@ -3,7 +3,7 @@
   "version": "2",
   "slug": "doods-noavx",
   "url": "https://github.com/snowzach/hassio-addons/tree/master/doods-noavx",
-  "description": "Distributed Open Object Detection Service for AMD64 SSE4.2",
+  "description": "Distributed Open Object Detection Service for AMD64 without AVX",
   "arch": [
     "armhf",
     "armv7",


### PR DESCRIPTION
Adds support for installing the noavx docker build - Some older hardware doesnt have support for AVX (Both my servers included)
This just adds the noavx variant to Hassio Addons