### PR TITLE
Add doods.log to addon schema

### DIFF
--- a/doods2-amd64-gpu/config.yaml
+++ b/doods2-amd64-gpu/config.yaml
@@ -64,6 +64,7 @@ schema:
   server:
     port: port?
     auth_key: str?
+  doods.log: str?
   doods.boxes:
     enabled: bool
     boxColor: str

--- a/doods2-amd64/config.yaml
+++ b/doods2-amd64/config.yaml
@@ -64,6 +64,7 @@ schema:
   server:
     port: port?
     auth_key: str?
+  doods.log: str?
   doods.boxes:
     enabled: bool
     boxColor: str

--- a/doods2/config.yaml
+++ b/doods2/config.yaml
@@ -67,6 +67,7 @@ schema:
   server:
     port: port?
     auth_key: str?
+  doods.log: str?
   doods.boxes:
     enabled: bool
     boxColor: str


### PR DESCRIPTION
Fixes warnings in supervisor:

`WARNING (MainThread) [supervisor.addons.options] Option 'doods.log' does not exist in the schema for DOODS2-amd64 (d5f40609_doods2-amd64)`

And makes `doods.log` available to configure in the UI.